### PR TITLE
fix: clippy in devshell

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -128,7 +128,7 @@
           drv = backend;
         };
 
-        devShells.default = craneLib.devShell {
+        devShells.default = craneLibLLvmTools.devShell {
           # Inherit inputs from checks.
           checks = self.checks.${system};
 


### PR DESCRIPTION
Clippy doesn't work in devshell, because rust-src was not in the toolchain